### PR TITLE
Added support for an `Off` command when used in multiswitch mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ function Switcheroo(log, config) {
 
         case 'multiswitch':
             this.multiswitch = config.multiswitch;
+            this.off_path = config.off_path;
             break;
 
         default:
@@ -88,7 +89,7 @@ Switcheroo.prototype = {
                     if (i === 0) return; // skip informationService at index 0
 
                     if (targetService.subtype === switchService.subtype) { // turn on
-                        reqUrl = this.host + this.multiswitch[i-1].path;
+                        reqUrl  = (this.off_path !== undefined && powerState) ? this.host + this.multiswitch[i-1].path : this.host + this.off_path;
                         switchService.getCharacteristic(Characteristic.On).setValue(true, undefined, funcContext);
                     } else { // turn off
                         switchService.getCharacteristic(Characteristic.On).setValue(false, undefined, funcContext);


### PR DESCRIPTION
This adds support for a new config key `off_path` when using multi-switch mode. The main driver for this change is to it can be used in conjunction with @maddox 's Logitech [Harmony API](https://github.com/maddox/harmony-api) to control a harmony based system.

If the `off_path` key is not set, the plugin maintains existing behaviour.